### PR TITLE
Signature fix

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -3881,7 +3881,7 @@ where
 				let funding_txo = find_funding_output(&chan, &splice_transaction)?;
 				log_trace!(self.logger, "... prev_funding_txinp {}  fund_tx_outpoint {} {}", prev_funding_txinp,  log_bytes!(funding_txo.txid), funding_txo.index);
 
-				let funding_res = chan.get_splice_created(splice_transaction, funding_txo, prev_funding_txinp, &self.logger)
+				let funding_res = chan.get_splice_created(splice_transaction, funding_txo, prev_funding_txinp, chan.context.get_value_satoshis(), &self.logger)
 					.map_err(|e| if let ChannelError::Close(msg) = e {
 						MsgHandleErrInternal::from_finish_shutdown(msg, chan.context.channel_id(), chan.context.get_user_id(), chan.context.force_shutdown(true), None, chan.context.get_value_satoshis())
 					} else { unreachable!(); });

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -503,6 +503,8 @@ pub struct SpliceCreated {
 	/// It could be also omitted and found by looking for the previous funding tx among the inputs.
 	/// Not needed in final version with tx negotiation, TODO remove
 	pub splice_prev_funding_input_index: u16,
+	/// The value of the previous funding transaction, the previous channel capacity
+	pub splice_prev_funding_input_value: u64,
 	/// Redeem script used in the splice transaction, needed for signing
 	/// Not needed in final version with tx negotiation, TODO remove
 	pub splice_tx_redeem_script: Script,
@@ -532,6 +534,8 @@ pub struct SpliceSigned {
 	/// It could be also omitted and found by looking for the previous funding tx among the inputs.
 	/// Not needed in final version with tx negotiation, TODO remove
 	pub splice_prev_funding_input_index: u16,
+	/// The value of the previous funding transaction, the previous channel capacity
+	pub splice_prev_funding_input_value: u64,
 	/// The signature of the splice acceptor (fundee) on the post-splice commitment transaction
 	pub signature: Signature,
 	/*
@@ -1890,6 +1894,7 @@ impl_writeable_msg!(SpliceCreated, {
 	funding_output_index,
 	splice_transaction,
 	splice_prev_funding_input_index,
+	splice_prev_funding_input_value,
 	splice_tx_redeem_script,
 	signature
 }, {});
@@ -1900,6 +1905,7 @@ impl_writeable_msg!(SpliceSigned, {
 	channel_id,
 	funding_signature,
 	splice_prev_funding_input_index,
+	splice_prev_funding_input_value,
 	signature
 }, {});
 

--- a/lightning/src/sign/mod.rs
+++ b/lightning/src/sign/mod.rs
@@ -552,7 +552,7 @@ pub trait EcdsaChannelSigner: ChannelSigner {
 
 	/// #SPLICING
 	/// Create a signature for a splicing funding transaction, for the input which is the previous funding tx.
-	fn sign_splicing_funding_input(&self, splicing_tx: &Transaction, splice_prev_funding_input_index: u16, prev_funding_value: u64, redeem_script: &Script, secp_ctx: &Secp256k1<secp256k1::All>) -> Result<Signature, ()>;
+	fn sign_splicing_funding_input(&self, splicing_tx: &Transaction, splice_prev_funding_input_index: u16, splice_prev_funding_input_value: u64, redeem_script: &Script, secp_ctx: &Secp256k1<secp256k1::All>) -> Result<Signature, ()>;
 }
 
 /// A writeable signer.
@@ -1129,12 +1129,12 @@ impl EcdsaChannelSigner for InMemorySigner {
 
 	/// #SPLICING
 	/// #SPLICE-SIG
-	fn sign_splicing_funding_input(&self, splicing_tx: &Transaction, splice_prev_funding_input_index: u16, prev_funding_value: u64, redeem_script: &Script, secp_ctx: &Secp256k1<secp256k1::All>) -> Result<Signature, ()> {
+	fn sign_splicing_funding_input(&self, splicing_tx: &Transaction, splice_prev_funding_input_index: u16, splice_prev_funding_input_value: u64, redeem_script: &Script, secp_ctx: &Secp256k1<secp256k1::All>) -> Result<Signature, ()> {
 		// println!("sign_splicing_funding_input  txlen {}  idx {}  val {}  tx {}", splicing_tx.encode().len(), splice_prev_funding_input_index, prev_funding_value, splicing_tx.encode().to_hex());
-		let sighash = &sighash::SighashCache::new(splicing_tx).segwit_signature_hash(splice_prev_funding_input_index as usize, &redeem_script, prev_funding_value, EcdsaSighashType::All).unwrap()[..];
+		let sighash = &sighash::SighashCache::new(splicing_tx).segwit_signature_hash(splice_prev_funding_input_index as usize, &redeem_script, splice_prev_funding_input_value, EcdsaSighashType::All).unwrap()[..];
 		let msg = hash_to_message!(sighash);
 		let sig = sign(secp_ctx, &msg, &self.funding_key);
-		// println!("sign_splicing_funding_input  hash {}  pubkey {} sig {}", sighash.to_hex(), &self.funding_key.public_key(secp_ctx), sig.serialize_der().to_hex());
+		// println!("sign_splicing_funding_input  hash {}  msg{}  pubkey {} sig {}  val {}", sighash.to_hex(), msg.to_hex(), &self.funding_key.public_key(secp_ctx), sig.serialize_der().to_hex(), splice_prev_funding_input_value);
 		Ok(sig)
 	}
 

--- a/lightning/src/util/test_channel_signer.rs
+++ b/lightning/src/util/test_channel_signer.rs
@@ -246,8 +246,8 @@ impl EcdsaChannelSigner for TestChannelSigner {
 		self.inner.sign_channel_announcement_with_funding_key(msg, secp_ctx)
 	}
 
-	fn sign_splicing_funding_input(&self, splicing_tx: &Transaction, splice_prev_funding_input_index: u16, prev_funding_value: u64, redeem_script: &Script, secp_ctx: &Secp256k1<secp256k1::All>) -> Result<Signature, ()> {
-		self.inner.sign_splicing_funding_input(splicing_tx, splice_prev_funding_input_index, prev_funding_value, redeem_script, secp_ctx)
+	fn sign_splicing_funding_input(&self, splicing_tx: &Transaction, splice_prev_funding_input_index: u16, splice_prev_funding_input_value: u64, redeem_script: &Script, secp_ctx: &Secp256k1<secp256k1::All>) -> Result<Signature, ()> {
+		self.inner.sign_splicing_funding_input(splicing_tx, splice_prev_funding_input_index, splice_prev_funding_input_value, redeem_script, secp_ctx)
 	}
 }
 


### PR DESCRIPTION
Proper sig. order, based on key order.
Proper value (used in sighash), always the _previous_ funding tx amount (prev channel capacity).
Fixes #1 

TODO:
- [x] Check with real E2E use case (testnet)